### PR TITLE
Fixes an underflow when loading rcImgs

### DIFF
--- a/animEx.cpp
+++ b/animEx.cpp
@@ -294,15 +294,17 @@ bool splitFiles(const char* cFilename)
 		vector<rectImgHelper> rih;
 		int k = 0;
 		//Loop per rectImg
-		for(int j = 0; j < rcImgs.size()-1; j++)
-		{
-			//Pull all rects in from this image
-			for(; k < rcImgs[j+1].rectStart; k++)
+		if (rcImgs.size() > 0) {
+			for(int j = 0; j < rcImgs.size()-1; j++)
 			{
-				rectImgHelper help;
-				help.img = rcImgs[j].img;
-				help.rc = fiRect[k];
-				rih.push_back(help);
+				//Pull all rects in from this image
+				for(; k < rcImgs[j+1].rectStart; k++)
+				{
+					rectImgHelper help;
+					help.img = rcImgs[j].img;
+					help.rc = fiRect[k];
+					rih.push_back(help);
+				}
 			}
 		}
 		


### PR DESCRIPTION
Some anim files, like Mermaid and Door, have the case where frameItem.numRects==0
This change checks for this case and doesn't try to iterate through them

rcImgs.size() is unsigned, so the for loop that checks for rcImgs.size()-1 would underflow and try to iterate to MAX_INT

An alternative solution is to change the for loop to iterate from j=1;rcImgs.size();j++, and update the appropriate variables, but that might not be as clear of intent.
